### PR TITLE
Add backup for blogpost and complete gitlab repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+blogpost-backup/nook-screen-master.tar.gz filter=lfs diff=lfs merge=lfs -text
+blogpost-backup/Turn[[:space:]]an[[:space:]]old[[:space:]]eReader[[:space:]]into[[:space:]]an[[:space:]]Information[[:space:]]Screen[[:space:]](Nook[[:space:]]STR)[[:space:]]–[[:space:]]Terence[[:space:]]Eden’s[[:space:]]Blog.pdf filter=lfs diff=lfs merge=lfs -text

--- a/blogpost-backup/Turn an old eReader into an Information Screen (Nook STR) – Terence Eden’s Blog.pdf
+++ b/blogpost-backup/Turn an old eReader into an Information Screen (Nook STR) – Terence Eden’s Blog.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd580642826f09a69d7a0c26cd04b71b57a9124694952650aee9e74e7905b615
+size 2038190

--- a/blogpost-backup/nook-screen-master.tar.gz
+++ b/blogpost-backup/nook-screen-master.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf4c032d33470d9665366a937d67e6a19aa19a456ca338ffd6df39c148ea05ce
+size 140102469


### PR DESCRIPTION
Being an upcycling project with old and discontinued stuff, the folder `blogpost-backup` contains a full backup of:

- https://gitlab.com/edent/nook-screen (contains also ElectricSign's apk and Nook full backup)
- https://shkspr.mobi/blog/2020/02/turn-an-old-ereader-into-an-information-screen-nook-str/
